### PR TITLE
Added recursive partials parsing and compiling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.idea
 /node_modules
 /*.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-.idea
 /node_modules
 /*.log

--- a/README.md
+++ b/README.md
@@ -112,6 +112,26 @@ See the [`gulp-define-module` documentation][gulp-define-module documentation] f
 `gulp-handlebars` also sets a default [`require`](https://github.com/wbyoung/gulp-define-module#optionsrequire) of `{ Handlebars: 'handlebars' }` for [`gulp-define-module`][gulp-define-module] so Handlebars will be present in when defining AMD, Node, CommonJS, or hybrid modules.
 
 
+## Compiling to various module systems and parse nested partials automatically
+
+If you are using module wrapper you are able to parse and register nested partials automatically by passing ```parsePartials: true```. In this case you should not require each partial as separate dependency in your modules, simply add only templates as dependency for your modules and plugin will goes through templates and find all nested partials recursively.
+
+```js
+var handlebars = require('gulp-handlebars');
+var defineModule = require('gulp-define-module');
+
+gulp.task('templates', function(){
+  // means what this filter covers templates and partials files
+  gulp.src(['client/templates/*.hbs'])
+    .pipe(handlebars({
+      parsePartials: true
+    }))
+    .pipe(defineModule('amd'))
+    .pipe(gulp.dest('build/js/'));
+});
+```
+
+
 ## API
 
 ### handlebars(options)

--- a/index.js
+++ b/index.js
@@ -92,13 +92,13 @@ module.exports = function(options) {
     file.path = gutil.replaceExtension(file.path, '.js');
 
     file.defineModuleOptions = _.defaults({
-      require: _.extend({ Handlebars: 'handlebars', __exports__: 'exports' }, defineModuleOptions.require, partialsDepsMap),
+      require: _.extend({ Handlebars: 'handlebars' }, defineModuleOptions.require, partialsDepsMap),
       context: _.extend({
         isPartial: isPartial,
         partialName: partialId,
         templateWrapper: templateWrapper
       }, defineModuleOptions.context),
-      wrapper: '__exports__["default"] = ' + (isPartial ? partialWrapper : templateWrapper)
+      wrapper: isPartial ? partialWrapper : templateWrapper
     }, defineModuleOptions);
 
     file.partialsRegistry = partialsRegistry;

--- a/index.js
+++ b/index.js
@@ -101,6 +101,8 @@ module.exports = function(options) {
       wrapper: isPartial ? partialWrapper : templateWrapper
     }, defineModuleOptions);
 
+    file.partialsRegistry = partialsRegistry;
+
     this.queue(file);
   });
 };

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ module.exports = function(options) {
             // extract the existing unique partial ID by path or generate the new one
             partialId = partialsRegistry[partialPath] || generateUniqueId(partialPath);
             // replace the partials occurrences to the unique partial ID
-            contents = contents.replace(new RegExp('>' + partialName, 'g'), '>' + partialId);
+            contents = contents.replace(new RegExp('>[\\s]+' + partialName, 'g'), '> ' + partialId);
             // add partial to the dependencies map, make relative if simple name
             partialsDepsMap[partialId] = partialName.match(/\.+\/+/gi) ? partialName : './' + partialName;
             // store the partial path to id relation

--- a/index.js
+++ b/index.js
@@ -5,9 +5,10 @@ var path = require('path');
 var gutil = require('gulp-util');
 var Handlebars = require('handlebars');
 var _ = require('underscore');
+var crypto = require('crypto');
 
-var generateUniqueId = function() {
-  return '_' + (new Date()).getTime();
+var generateUniqueId = function(s) {
+  return '_' + crypto.createHash('md5').update(s).digest('hex');
 };
 
 module.exports = function(options) {

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var through = require('through');
 var path = require('path');
 var gutil = require('gulp-util');
 var Handlebars = require('handlebars');
-var _ = require('underscore');
+var _ = require('lodash');
 var crypto = require('crypto');
 
 var generateUniqueId = function(s) {

--- a/index.js
+++ b/index.js
@@ -15,7 +15,11 @@ module.exports = function(options) {
   var opts = options || {};
   var compilerOptions = opts.compilerOptions || {};
   var partialsRegistry = {};
-  var defineModuleOptions = opts.defineModuleOptions || {};
+  var defineModuleOptions = opts.defineModuleOptions || {
+    context: {
+      handlebars: 'Handlebars.template(<%= contents %>)'
+    }
+  };
   var templateWrapper = opts.templateWrapper || 'Handlebars.template(<%= contents %>)';
   var partialWrapper = opts.partialWrapper || 'Handlebars.registerPartial("<%= partialName %>", <%= templateWrapper %>)';
 
@@ -84,7 +88,7 @@ module.exports = function(options) {
       return this.emit('error', err);
     }
 
-    file.contents = new Buffer(compiled);
+    file.contents = new Buffer(compiled);    
     file.path = gutil.replaceExtension(file.path, '.js');
 
     file.defineModuleOptions = _.defaults({

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ module.exports = function(options) {
     var partialId = null;
     var partialsDepsMap = {};
     var partialsPrefix = opts.partialsPrefix || '_';
-    var isPartialFile = path.basename(file.relative)[0] === partialsPrefix;
+    var isPartial = path.basename(file.relative)[0] === partialsPrefix;
 
     if (opts.parsePartials) {
       try {
@@ -59,7 +59,7 @@ module.exports = function(options) {
     }
 
     // store the partial data into registry
-    if (isPartialFile) {
+    if (isPartial) {
       // extract the partial path
       var partialPath = path.join(path.resolve(path.dirname(file.relative)), path.basename(file.relative, '.hbs'));
       // extract the existing unique partial ID by path or generate the new one
@@ -80,8 +80,12 @@ module.exports = function(options) {
 
     file.defineModuleOptions = _.defaults({
       require: _.extend({ Handlebars: 'handlebars' }, defineModuleOptions.require, partialsDepsMap),
-      context: _.extend({ partialName: partialId, templateWrapper: templateWrapper }, defineModuleOptions.context),
-      wrapper: isPartialFile ? partialWrapper : templateWrapper
+      context: _.extend({
+        isPartial: isPartial,
+        partialName: partialId,
+        templateWrapper: templateWrapper
+      }, defineModuleOptions.context),
+      wrapper: isPartial ? partialWrapper : templateWrapper
     }, defineModuleOptions);
 
     this.queue(file);

--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ module.exports = function(options) {
       return this.emit('error', err);
     }
 
-    file.contents = new Buffer(compiled);    
+    file.contents = new Buffer(compiled);
     file.path = gutil.replaceExtension(file.path, '.js');
 
     file.defineModuleOptions = _.defaults({

--- a/index.js
+++ b/index.js
@@ -92,13 +92,13 @@ module.exports = function(options) {
     file.path = gutil.replaceExtension(file.path, '.js');
 
     file.defineModuleOptions = _.defaults({
-      require: _.extend({ Handlebars: 'handlebars' }, defineModuleOptions.require, partialsDepsMap),
+      require: _.extend({ Handlebars: 'handlebars', __exports__: 'exports' }, defineModuleOptions.require, partialsDepsMap),
       context: _.extend({
         isPartial: isPartial,
         partialName: partialId,
         templateWrapper: templateWrapper
       }, defineModuleOptions.context),
-      wrapper: isPartial ? partialWrapper : templateWrapper
+      wrapper: '__exports__["default"] = ' + (isPartial ? partialWrapper : templateWrapper)
     }, defineModuleOptions);
 
     file.partialsRegistry = partialsRegistry;

--- a/index.js
+++ b/index.js
@@ -20,8 +20,8 @@ module.exports = function(options) {
       handlebars: 'Handlebars.template(<%= contents %>)'
     }
   };
-  var templateWrapper = opts.templateWrapper || 'Handlebars.template(<%= contents %>)';
-  var partialWrapper = opts.partialWrapper || '(function() { var __cTemplate = <%= templateWrapper %>; Handlebars.registerPartial("<%= partialName %>", __cTemplate); return __cTemplate; })()';
+  var templateWrapper = opts.templateWrapper || '(function() { var __cTemplate = Handlebars.template(<%= contents %>); __cTemplate["default"] = __cTemplate; return __cTemplate; })()';
+  var partialWrapper = opts.partialWrapper || '(function() { var __cTemplate = <%= templateWrapper %>; Handlebars.registerPartial("<%= partialName %>", __cTemplate); __cTemplate["default"] = __cTemplate; return __cTemplate; })()';
 
   return through(function(file) {
     if (file.isNull()) {

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports = function(options) {
     }
   };
   var templateWrapper = opts.templateWrapper || 'Handlebars.template(<%= contents %>)';
-  var partialWrapper = opts.partialWrapper || 'Handlebars.registerPartial("<%= partialName %>", <%= templateWrapper %>)';
+  var partialWrapper = opts.partialWrapper || '(function() { var __cTemplate = <%= templateWrapper %>; Handlebars.registerPartial("<%= partialName %>", __cTemplate); return __cTemplate; })()';
 
   return through(function(file) {
     if (file.isNull()) {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "dependencies": {
     "through": "~2.3.0",
     "handlebars": "^1.3.0",
-    "gulp-util": "~2.2.0"
+    "gulp-util": "~2.2.0",
+    "lodash": "2.4.1"
   },
   "devDependencies": {
     "should": "~2.1.1",

--- a/test/expected/Basic_with_nested_partial.js
+++ b/test/expected/Basic_with_nested_partial.js
@@ -1,11 +1,11 @@
-define(['handlebars','./_basic_partial_with_nested'], function(Handlebars,_94e8ceec2cb635d72df145bf24fea501) { return Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
+define(['handlebars','./_basic_partial_with_nested'], function(Handlebars,_basic_partial_with_nested) { return Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
   this.compilerInfo = [4,'>= 1.0.0'];
 helpers = this.merge(helpers, Handlebars.helpers); partials = this.merge(partials, Handlebars.partials); data = data || {};
   var buffer = "", stack1, self=this;
 
 
   buffer += "Basic template - ";
-  stack1 = self.invokePartial(partials._94e8ceec2cb635d72df145bf24fea501, '_94e8ceec2cb635d72df145bf24fea501', depth0, helpers, partials, data);
+  stack1 = self.invokePartial(partials._basic_partial_with_nested, '_basic_partial_with_nested', depth0, helpers, partials, data);
   if(stack1 || stack1 === 0) { buffer += stack1; }
   return buffer;
   }); });

--- a/test/expected/Basic_with_nested_partial.js
+++ b/test/expected/Basic_with_nested_partial.js
@@ -1,0 +1,11 @@
+define(['handlebars','./_basic_partial_with_nested'], function(Handlebars,_94e8ceec2cb635d72df145bf24fea501) { return Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
+  this.compilerInfo = [4,'>= 1.0.0'];
+helpers = this.merge(helpers, Handlebars.helpers); partials = this.merge(partials, Handlebars.partials); data = data || {};
+  var buffer = "", stack1, self=this;
+
+
+  buffer += "Basic template - ";
+  stack1 = self.invokePartial(partials._94e8ceec2cb635d72df145bf24fea501, '_94e8ceec2cb635d72df145bf24fea501', depth0, helpers, partials, data);
+  if(stack1 || stack1 === 0) { buffer += stack1; }
+  return buffer;
+  }); });

--- a/test/expected/Basic_with_partial.js
+++ b/test/expected/Basic_with_partial.js
@@ -1,0 +1,11 @@
+define(['handlebars','./_basic_partial'], function(Handlebars,_ea1f7485d5b8611651421a82fc9840ce) { return Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
+  this.compilerInfo = [4,'>= 1.0.0'];
+helpers = this.merge(helpers, Handlebars.helpers); partials = this.merge(partials, Handlebars.partials); data = data || {};
+  var buffer = "", stack1, self=this;
+
+
+  buffer += "Basic template - ";
+  stack1 = self.invokePartial(partials._ea1f7485d5b8611651421a82fc9840ce, '_ea1f7485d5b8611651421a82fc9840ce', depth0, helpers, partials, data);
+  if(stack1 || stack1 === 0) { buffer += stack1; }
+  return buffer;
+  }); });

--- a/test/expected/Basic_with_partial.js
+++ b/test/expected/Basic_with_partial.js
@@ -1,11 +1,11 @@
-define(['handlebars','./_basic_partial'], function(Handlebars,_ea1f7485d5b8611651421a82fc9840ce) { return Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
+define(['handlebars','./_basic_partial'], function(Handlebars,_basic_partial) { return Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
   this.compilerInfo = [4,'>= 1.0.0'];
 helpers = this.merge(helpers, Handlebars.helpers); partials = this.merge(partials, Handlebars.partials); data = data || {};
   var buffer = "", stack1, self=this;
 
 
   buffer += "Basic template - ";
-  stack1 = self.invokePartial(partials._ea1f7485d5b8611651421a82fc9840ce, '_ea1f7485d5b8611651421a82fc9840ce', depth0, helpers, partials, data);
+  stack1 = self.invokePartial(partials._basic_partial, '_basic_partial', depth0, helpers, partials, data);
   if(stack1 || stack1 === 0) { buffer += stack1; }
   return buffer;
   }); });

--- a/test/expected/_basic_nested_partial.js
+++ b/test/expected/_basic_nested_partial.js
@@ -1,0 +1,8 @@
+define(['handlebars'], function(Handlebars) { return Handlebars.registerPartial("_e390b316994ff22619f015b3cce7b2fa", Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
+  this.compilerInfo = [4,'>= 1.0.0'];
+helpers = this.merge(helpers, Handlebars.helpers); data = data || {};
+  
+
+
+  return "nested partial";
+  })); });

--- a/test/expected/_basic_nested_partial.js
+++ b/test/expected/_basic_nested_partial.js
@@ -1,4 +1,4 @@
-define(['handlebars'], function(Handlebars) { return Handlebars.registerPartial("_e390b316994ff22619f015b3cce7b2fa", Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
+define(['handlebars'], function(Handlebars) { return Handlebars.registerPartial("_basic_nested_partial", Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
   this.compilerInfo = [4,'>= 1.0.0'];
 helpers = this.merge(helpers, Handlebars.helpers); data = data || {};
   

--- a/test/expected/_basic_nested_partial.js
+++ b/test/expected/_basic_nested_partial.js
@@ -1,8 +1,8 @@
-define(['handlebars'], function(Handlebars) { return Handlebars.registerPartial("_basic_nested_partial", Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
+define(['handlebars'], function(Handlebars) { return (function() { var __cTemplate = Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
   this.compilerInfo = [4,'>= 1.0.0'];
 helpers = this.merge(helpers, Handlebars.helpers); data = data || {};
   
 
 
   return "nested partial";
-  })); });
+  }); Handlebars.registerPartial("_basic_nested_partial", __cTemplate); return __cTemplate; })(); });

--- a/test/expected/_basic_partial.js
+++ b/test/expected/_basic_partial.js
@@ -1,4 +1,4 @@
-define(['handlebars'], function(Handlebars) { return Handlebars.registerPartial("_ea1f7485d5b8611651421a82fc9840ce", Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
+define(['handlebars'], function(Handlebars) { return Handlebars.registerPartial("_basic_partial", Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
   this.compilerInfo = [4,'>= 1.0.0'];
 helpers = this.merge(helpers, Handlebars.helpers); data = data || {};
   

--- a/test/expected/_basic_partial.js
+++ b/test/expected/_basic_partial.js
@@ -1,0 +1,8 @@
+define(['handlebars'], function(Handlebars) { return Handlebars.registerPartial("_ea1f7485d5b8611651421a82fc9840ce", Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
+  this.compilerInfo = [4,'>= 1.0.0'];
+helpers = this.merge(helpers, Handlebars.helpers); data = data || {};
+  
+
+
+  return "basic partial";
+  })); });

--- a/test/expected/_basic_partial.js
+++ b/test/expected/_basic_partial.js
@@ -1,8 +1,8 @@
-define(['handlebars'], function(Handlebars) { return Handlebars.registerPartial("_basic_partial", Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
+define(['handlebars'], function(Handlebars) { return (function() { var __cTemplate = Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
   this.compilerInfo = [4,'>= 1.0.0'];
 helpers = this.merge(helpers, Handlebars.helpers); data = data || {};
   
 
 
   return "basic partial";
-  })); });
+  }); Handlebars.registerPartial("_basic_partial", __cTemplate); return __cTemplate; })(); });

--- a/test/expected/_basic_partial_with_nested.js
+++ b/test/expected/_basic_partial_with_nested.js
@@ -1,11 +1,11 @@
-define(['handlebars','./_basic_nested_partial'], function(Handlebars,_e390b316994ff22619f015b3cce7b2fa) { return Handlebars.registerPartial("_94e8ceec2cb635d72df145bf24fea501", Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
+define(['handlebars','./_basic_nested_partial'], function(Handlebars,_basic_nested_partial) { return Handlebars.registerPartial("_basic_partial_with_nested", Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
   this.compilerInfo = [4,'>= 1.0.0'];
 helpers = this.merge(helpers, Handlebars.helpers); partials = this.merge(partials, Handlebars.partials); data = data || {};
   var buffer = "", stack1, self=this;
 
 
   buffer += "basic partial with nested ";
-  stack1 = self.invokePartial(partials._e390b316994ff22619f015b3cce7b2fa, '_e390b316994ff22619f015b3cce7b2fa', depth0, helpers, partials, data);
+  stack1 = self.invokePartial(partials._basic_nested_partial, '_basic_nested_partial', depth0, helpers, partials, data);
   if(stack1 || stack1 === 0) { buffer += stack1; }
   return buffer;
   })); });

--- a/test/expected/_basic_partial_with_nested.js
+++ b/test/expected/_basic_partial_with_nested.js
@@ -1,4 +1,4 @@
-define(['handlebars','./_basic_nested_partial'], function(Handlebars,_basic_nested_partial) { return Handlebars.registerPartial("_basic_partial_with_nested", Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
+define(['handlebars','./_basic_nested_partial'], function(Handlebars,_basic_nested_partial) { return (function() { var __cTemplate = Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
   this.compilerInfo = [4,'>= 1.0.0'];
 helpers = this.merge(helpers, Handlebars.helpers); partials = this.merge(partials, Handlebars.partials); data = data || {};
   var buffer = "", stack1, self=this;
@@ -8,4 +8,4 @@ helpers = this.merge(helpers, Handlebars.helpers); partials = this.merge(partial
   stack1 = self.invokePartial(partials._basic_nested_partial, '_basic_nested_partial', depth0, helpers, partials, data);
   if(stack1 || stack1 === 0) { buffer += stack1; }
   return buffer;
-  })); });
+  }); Handlebars.registerPartial("_basic_partial_with_nested", __cTemplate); return __cTemplate; })(); });

--- a/test/expected/_basic_partial_with_nested.js
+++ b/test/expected/_basic_partial_with_nested.js
@@ -1,0 +1,11 @@
+define(['handlebars','./_basic_nested_partial'], function(Handlebars,_e390b316994ff22619f015b3cce7b2fa) { return Handlebars.registerPartial("_94e8ceec2cb635d72df145bf24fea501", Handlebars.template(function (Handlebars,depth0,helpers,partials,data) {
+  this.compilerInfo = [4,'>= 1.0.0'];
+helpers = this.merge(helpers, Handlebars.helpers); partials = this.merge(partials, Handlebars.partials); data = data || {};
+  var buffer = "", stack1, self=this;
+
+
+  buffer += "basic partial with nested ";
+  stack1 = self.invokePartial(partials._e390b316994ff22619f015b3cce7b2fa, '_e390b316994ff22619f015b3cce7b2fa', depth0, helpers, partials, data);
+  if(stack1 || stack1 === 0) { buffer += stack1; }
+  return buffer;
+  })); });

--- a/test/fixtures/Basic_with_nested_partial.hbs
+++ b/test/fixtures/Basic_with_nested_partial.hbs
@@ -1,0 +1,1 @@
+Basic template - {{> _basic_partial_with_nested}}

--- a/test/fixtures/Basic_with_partial.hbs
+++ b/test/fixtures/Basic_with_partial.hbs
@@ -1,0 +1,1 @@
+Basic template - {{> _basic_partial}}

--- a/test/fixtures/_basic_nested_partial.hbs
+++ b/test/fixtures/_basic_nested_partial.hbs
@@ -1,0 +1,1 @@
+nested partial

--- a/test/fixtures/_basic_partial.hbs
+++ b/test/fixtures/_basic_partial.hbs
@@ -1,0 +1,1 @@
+basic partial

--- a/test/fixtures/_basic_partial_with_nested.hbs
+++ b/test/fixtures/_basic_partial_with_nested.hbs
@@ -1,0 +1,1 @@
+basic partial with nested {{> _basic_nested_partial}}

--- a/test/main.js
+++ b/test/main.js
@@ -4,6 +4,7 @@ var should = require('should');
 var gutil = require('gulp-util');
 var fs = require('fs');
 var path = require('path');
+var _ = require('lodash');
 require('mocha');
 
 var getFixture = function(filePath) {
@@ -107,6 +108,88 @@ describe('gulp-handlebars', function() {
         done();
       });
       hbsStream.write(basicTemplate);
+      hbsStream.end();
+    });
+
+    it('should compile template and register nested partial', function(done) {
+      var hbsStream = handlebarsPlugin({ parsePartials: true });
+      var basicTemplate = getFixture('Basic_with_partial.hbs');
+      hbsStream.pipe(defineModule('amd'));
+
+      hbsStream.on('data', function(newFile) {
+        should.exist(newFile);
+        should.exist(newFile.contents);
+        should.exist(newFile.partialsRegistry);
+        should.equal(_(newFile.partialsRegistry).values().first(), '_ea1f7485d5b8611651421a82fc9840ce');
+        fileMatchesExpected(newFile, 'Basic_with_partial.js', 'Basic_with_partial.js');
+        done();
+      });
+      hbsStream.write(basicTemplate);
+      hbsStream.end();
+    });
+
+    it('should compile template, partial and register nested partial', function(done) {
+      var hbsStream = handlebarsPlugin({ parsePartials: true });
+      var basicTemplate = getFixture('Basic_with_partial.hbs');
+      var basicPartial = getFixture('_basic_partial.hbs');
+      hbsStream.pipe(defineModule('amd'));
+
+      hbsStream.on('data', function(newFile) {
+        should.exist(newFile);
+        should.exist(newFile.contents);
+        should.exist(newFile.partialsRegistry);
+        should.equal(_(newFile.partialsRegistry).values().first(), '_ea1f7485d5b8611651421a82fc9840ce');
+
+        switch (path.basename(newFile.path)) {
+          case 'Basic_with_partial.js':
+            fileMatchesExpected(newFile, 'Basic_with_partial.js', 'Basic_with_partial.js');
+            break;
+          case '_basic_partial.js':
+            fileMatchesExpected(newFile, '_basic_partial.js', '_basic_partial.js');
+            done();
+            break;
+        }
+      });
+      hbsStream.write(basicTemplate);
+      hbsStream.write(basicPartial);
+      hbsStream.end();
+    });
+
+    it('should compile template, partial and register nested partials', function(done) {
+      var hbsStream = handlebarsPlugin({ parsePartials: true });
+      var basicTemplateWithNestedPartial = getFixture('Basic_with_nested_partial.hbs');
+      var basicPartialWithNestedPartial = getFixture('_basic_partial_with_nested.hbs');
+      var basicNestedPartial = getFixture('_basic_nested_partial.hbs');
+      hbsStream.pipe(defineModule('amd'));
+
+      hbsStream.on('data', function(newFile) {
+        should.exist(newFile);
+        should.exist(newFile.contents);
+        should.exist(newFile.partialsRegistry);
+
+        switch (path.basename(newFile.path)) {
+          case 'Basic_with_nested_partial.js':
+            fileMatchesExpected(newFile, 'Basic_with_nested_partial.js', 'Basic_with_nested_partial.js');
+            // first nested partial found and registered
+            should.deepEqual(_(newFile.partialsRegistry).values().value(), ['_94e8ceec2cb635d72df145bf24fea501']);
+            break;
+          case '_basic_partial_with_nested.js':
+            fileMatchesExpected(newFile, '_basic_partial_with_nested.js', '_basic_partial_with_nested.js');
+            // two nested partials found and registered
+            should.deepEqual(_(newFile.partialsRegistry).values().value(), ['_94e8ceec2cb635d72df145bf24fea501', '_e390b316994ff22619f015b3cce7b2fa']);
+            break;
+          case '_basic_nested_partial.js':
+            fileMatchesExpected(newFile, '_basic_nested_partial.js', '_basic_nested_partial.js');
+            // two nested partials found and registered and do not have redundant items
+            should.deepEqual(_(newFile.partialsRegistry).values().value(), ['_94e8ceec2cb635d72df145bf24fea501', '_e390b316994ff22619f015b3cce7b2fa']);
+
+            done();
+            break;
+        }
+      });
+      hbsStream.write(basicTemplateWithNestedPartial);
+      hbsStream.write(basicPartialWithNestedPartial);
+      hbsStream.write(basicNestedPartial);
       hbsStream.end();
     });
   });

--- a/test/main.js
+++ b/test/main.js
@@ -123,14 +123,20 @@ describe('gulp-handlebars', function() {
     it('should compile template and register nested partial', function(done) {
       var hbsStream = handlebarsPlugin({ parsePartials: true });
       var basicTemplate = getFixture('Basic_with_partial.hbs');
+      var basicPartialUID = generateUniqueId(getAbsolutePartialPath('_basic_partial.hbs'));
       hbsStream.pipe(defineModule('amd'));
 
       hbsStream.on('data', function(newFile) {
         should.exist(newFile);
         should.exist(newFile.contents);
         should.exist(newFile.partialsRegistry);
-        should.equal(_(newFile.partialsRegistry).values().first(), '_ea1f7485d5b8611651421a82fc9840ce');
+        should.equal(_(newFile.partialsRegistry).values().first(), basicPartialUID);
+
+        // actualize partial uid
+        newFile.contents = new Buffer(newFile.contents.toString().replace(new RegExp(basicPartialUID, 'g'), '_basic_partial'));
+
         fileMatchesExpected(newFile, 'Basic_with_partial.js', 'Basic_with_partial.js');
+
         done();
       });
       hbsStream.write(basicTemplate);
@@ -141,13 +147,17 @@ describe('gulp-handlebars', function() {
       var hbsStream = handlebarsPlugin({ parsePartials: true });
       var basicTemplate = getFixture('Basic_with_partial.hbs');
       var basicPartial = getFixture('_basic_partial.hbs');
+      var basicPartialUID = generateUniqueId(getAbsolutePartialPath('_basic_partial.hbs'));
       hbsStream.pipe(defineModule('amd'));
 
       hbsStream.on('data', function(newFile) {
         should.exist(newFile);
         should.exist(newFile.contents);
         should.exist(newFile.partialsRegistry);
-        should.equal(_(newFile.partialsRegistry).values().first(), '_ea1f7485d5b8611651421a82fc9840ce');
+        should.equal(_(newFile.partialsRegistry).values().first(), basicPartialUID);
+
+        // actualize partial uid
+        newFile.contents = new Buffer(newFile.contents.toString().replace(new RegExp(basicPartialUID, 'g'), '_basic_partial'));
 
         switch (path.basename(newFile.path)) {
           case 'Basic_with_partial.js':


### PR DESCRIPTION
Added new optional option ```parsePartials: true``` in this case will be found all partials inside the templates and registered/wrapped into appropriate instance/module.

```js
var handlebars = require('gulp-handlebars');
var defineModule = require('gulp-define-module');

gulp.task('templates', function(){
  gulp.src(['templates/*.hbs'])
    .pipe(handlebars({
        parsePartials: true
    }))
    .pipe(defineModule('node'))
    .pipe(gulp.dest('build/templates/'));
});
```