### PR TITLE
Handling compile errors so it doesnt halt gulp watch tasks

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports = function(options) {
       compiled = Handlebars.precompile(contents, compilerOptions).toString();
     }
     catch (err) {
-      console.log(err);
+      console.log(err.message);
       compiled = Handlebars.precompile("{{ log '[gulp-handlebars] Error compiling: " + file.path + "' }}", compilerOptions).toString();
     }
 


### PR DESCRIPTION
When running gulp-handlebars in conjunction with gulp watch, errors are "thrown".  This causes the gulp watch task to halt.  Here the error message is logged to the console and the compiled template outputs an error message.
