### PR TITLE
Require runtime only. Fixes #52

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ module.exports = function(opts) {
     // Options that take effect when used with gulp-define-module
     file.defineModuleOptions = {
       require: {
-        Handlebars: 'handlebars'
+        Handlebars: 'handlebars/runtime'
       },
       context: {
         handlebars: 'Handlebars.template(<%= contents %>)'


### PR DESCRIPTION
This makes the browserified version much smaller, as the compiler isn't needed.