### PR TITLE
Make extension-setting gulp-version-agnostic

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var through2 = require('through2');
 var PluginError = require('plugin-error');
+const path = require('path');
 
 const PLUGIN_NAME = 'gulp-handlebars';
 
@@ -45,7 +46,15 @@ module.exports = function(opts) {
     }
 
     file.contents = new Buffer(compiled);
-    file.extname = '.js';
+
+    /**
+     * Update the file's extension gulp-version-agnostically. Set `base` to `null` so that `path`
+     * respects our updated `ext` value.
+     */
+    const pathParts = path.parse(file.path);
+    pathParts.base = null;
+    pathParts.ext = '.js';
+    file.path = path.format(pathParts);
 
     // Options that take effect when used with gulp-define-module
     file.defineModuleOptions = {


### PR DESCRIPTION
Fixes https://github.com/lazd/gulp-handlebars/issues/89.

---

This change can be tested by `link`ing this branch of `gulp-handlebars` in the [bug demonstration repo](https://github.com/spencer-brown/gulp-handlebars-bug-demo) I made.