### PR TITLE
Fix extension renaming

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var through2 = require('through2');
 var PluginError = require('plugin-error');
 const path = require('path');
+const replaceExt = require('replace-ext');
 
 const PLUGIN_NAME = 'gulp-handlebars';
 
@@ -46,15 +47,7 @@ module.exports = function(opts) {
     }
 
     file.contents = new Buffer(compiled);
-
-    /**
-     * Update the file's extension gulp-version-agnostically. Set `base` to `null` so that `path`
-     * respects our updated `ext` value.
-     */
-    const pathParts = path.parse(file.path);
-    pathParts.base = null;
-    pathParts.ext = '.js';
-    file.path = path.format(pathParts);
+    file.path = replaceExt(file.path, '.js');
 
     // Options that take effect when used with gulp-define-module
     file.defineModuleOptions = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-handlebars",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2815,6 +2815,12 @@
             "util-deprecate": "1.0.2"
           }
         },
+        "replace-ext": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+          "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+          "dev": true
+        },
         "string_decoder": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
@@ -4352,10 +4358,9 @@
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
     "replace-ext": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-      "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
-      "dev": true
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+      "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
     },
     "replace-homedir": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "handlebars": "^4.0.0",
     "plugin-error": "^0.1.2",
+    "replace-ext": "^1.0.0",
     "through2": "^2.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
This replaces the somewhat makeshift solution for handling the extension renaming with the solution recommended by the gulp-util deprecation notes. It uses `replace-ext`, and should be compatible with gulp 3 and 4.

Fixes #91.